### PR TITLE
:arrow_up: Version up rake

### DIFF
--- a/sakamichi_scraper.gemspec
+++ b/sakamichi_scraper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "1.10.10"
   spec.add_development_dependency "bundler", "2.1.4"
   spec.add_development_dependency "pry", "0.13.1"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "1.11.0"
 end


### PR DESCRIPTION
rakeのバージョンアップ

## before
https://rubygems.org/gems/rake/versions/10.5.0

## after
https://rubygems.org/gems/rake/versions/12.3.3