### PR TITLE
メンバー名を返す関数追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,7 @@ Lint/MissingSuper:
 #メソッド行上限を20行にする
 Metrics/MethodLength:
   Max: 20
+
+# トップレベルにコメントはなくてもいいので
+Documentation:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/config/member_list/sakurazaka.yml
+++ b/config/member_list/sakurazaka.yml
@@ -1,0 +1,145 @@
+- 03:
+  - name_ja: "上村莉菜"
+    name_ja_hiragana: "うえむらりな"
+    name_en: "Rina Uemura"
+  - gen: 1st
+- 06:
+  - name_ja: "小池美波"
+    name_ja_hiragana: "こいけみなみ"
+    name_en: "Minami Koike"
+  - gen: 1st
+- 07:
+  - name_ja: "小林由依"
+    name_ja_hiragana: "こばやしゆい"
+    name_en: "Yui Kobayashi"
+  - gen: 1st
+- 8:
+  - name_ja: "齋藤冬優花"
+    name_ja_hiragana: "さいとうふゆか"
+    name_en: "Fuyuka Saito"
+  - gen: 1st
+- 14:
+  - name_ja: "土生瑞穂"
+    name_ja_hiragana: "はぶみづほ"
+    name_en: "Mizuho Habu"
+  - gen: 1st
+- 43:
+  - name_ja: "井上梨名"
+    name_ja_hiragana: "いのうえりな"
+    name_en: "Rina Inoue"
+  - gen: 2nd
+- 53:
+  - name_ja: "遠藤光莉"
+    name_ja_hiragana: "えんどうひかり"
+    name_en: "Hikari Endo"
+  - gen: 2nd
+- 54:
+  - name_ja: "大園玲"
+    name_ja_hiragana: "おおぞのれい"
+    name_en: "Rei Ozono"
+  - gen: 2nd
+- 55:
+  - name_ja: "大沼晶保"
+    name_ja_hiragana: "おおぬまおきほ"
+    name_en: "Akiho Onuma"
+  - gen: 2nd
+- 56:
+  - name_ja: "幸坂茉里乃"
+    name_ja_hiragana: "こうさかまりの"
+    name_en: "Marino Kosaka"
+  - gen: 2nd
+- 45:
+  - name_ja: "武元唯衣"
+    name_ja_hiragana: "たけもとゆい"
+    name_en: "Yui Takemoto"
+  - gen: 2nd
+- 46:
+  - name_ja: "田村保乃"
+    name_ja_hiragana: "たむらほの"
+    name_en: "Hono Tamura"
+  - gen: 2nd
+- 47:
+  - name_ja: "藤吉夏鈴"
+    name_ja_hiragana: "ふじよしかりん"
+    name_en: "Karin Fujiyoshi"
+  - gen: 2nd
+- 57:
+  - name_ja: "増本綺良"
+    name_ja_hiragana: "ますもときら"
+    name_en: "Kira Masumoto"
+  - gen: 2nd
+- 48:
+  - name_ja: "松田里奈"
+    name_ja_hiragana: "まつだりな"
+    name_en: "Rina Matsuda"
+  - gen: 2nd
+- 50:
+  - name_ja: "森田ひかる"
+    name_ja_hiragana: "もりたひかる"
+    name_en: "Hikaru Morita"
+  - gen: 2nd
+- 58:
+  - name_ja: "守屋麗奈"
+    name_ja_hiragana: "もりやれな"
+    name_en: "Rena Moriya"
+  - gen: 2nd
+- 57:
+  - name_ja: "山﨑天"
+    name_ja_hiragana: "やまさきてん"
+    name_en: "Ten Yamasaki"
+  - gen: 2nd
+- 59:
+  - name_ja: "石森璃花"
+    name_ja_hiragana: "いしもりりか"
+    name_en: "Rika Ishimori"
+  - gen: 3rd
+- 60:
+  - name_ja: "遠藤理子"
+    name_ja_hiragana: "えんどうりこ"
+    name_en: "Riko Endo"
+  - gen: 3rd
+- 61:
+  - name_ja: "小田倉麗奈"
+    name_ja_hiragana: "おだくられいな"
+    name_en: "Reina Odakura"
+  - gen: 3rd
+- 62:
+  - name_ja: "小島凪紗"
+    name_ja_hiragana: "こじまなぎさ"
+    name_en: "Nagisa Kojima"
+  - gen: 3rd
+- 63:
+  - name_ja: "谷口愛梨"
+    name_ja_hiragana: "たにぐちあいり"
+    name_en: "Airi Taniguchi"
+  - gen: 3rd
+- 64:
+  - name_ja: "中島優月"
+    name_ja_hiragana: "なかしまゆづき"
+    name_en: "Yuzuki Nakashima"
+  - gen: 3rd
+- 65:
+  - name_ja: "的野美青"
+    name_ja_hiragana: "まとのみお"
+    name_en: "Mio Matono"
+  - gen: 3rd
+- 66:
+  - name_ja: "向井純葉"
+    name_ja_hiragana: "むかいいとは"
+    name_en: "Itoha Mukai"
+  - gen: 3rd
+- 67:
+  - name_ja: "村井優"
+    name_ja_hiragana: "むらいゆう"
+    name_en: "Yu Murai"
+  - gen: 3rd
+- 68:
+  - name_ja: "村山美羽"
+    name_ja_hiragana: "むらやまみう"
+    name_en: "Miu Murayama"
+  - gen: 3rd
+- 69:
+  - name_ja: "山下瞳月"
+    name_ja_hiragana: "やましたしづき"
+    name_en: "Shizuki Yamashita"
+  - gen: 3rd

--- a/lib/sakamichi_scraper/base.rb
+++ b/lib/sakamichi_scraper/base.rb
@@ -72,5 +72,18 @@ module SakamichiScraper
         end
       end
     end
+
+    def member_list
+      YAML.load_file("config/member_list/#{@group_name}.yml")
+    end
+
+    def extract_member_list(target:)
+      name_list = []
+      member_list.each do |member|
+        name_list << member.values.flatten!.first[target.to_s]
+      end
+
+      name_list
+    end
   end
 end

--- a/lib/sakamichi_scraper/base.rb
+++ b/lib/sakamichi_scraper/base.rb
@@ -8,7 +8,7 @@ module SakamichiScraper
     end
 
     def init_url_from_yml(group_name, yml_key)
-      url = YAML.load_file("config/url.yml")["#{group_name}"]["#{yml_key}"]
+      url = YAML.load_file("config/url.yml")[group_name.to_s][yml_key.to_s]
       get_content(url)
     end
 
@@ -41,7 +41,7 @@ module SakamichiScraper
     end
 
     def exclude_img_path(group_name)
-      YAML.load_file("config/url.yml")["#{group_name}"]["exclude_img_path"]
+      YAML.load_file("config/url.yml")[group_name.to_s]["exclude_img_path"]
     end
 
     def image_file_path

--- a/lib/sakamichi_scraper/hinatazaka.rb
+++ b/lib/sakamichi_scraper/hinatazaka.rb
@@ -12,15 +12,15 @@ module SakamichiScraper
 
     def newest_blog_title
       scraped_title = Nokogiri.parse(blog_top_page, nil, nil)
-                        .at_css(".p-blog-main__head > .c-blog-main__title")
-                        .content
+                              .at_css(".p-blog-main__head > .c-blog-main__title")
+                              .content
       format_content(scraped_title)
     end
 
     def recent_blog_info
       res = []
       Nokogiri.parse(blog_top_page, nil, nil).css(".p-blog-top__list > li").each do |c|
-        info_arr = c.content.strip.split("\n").reject { |i| i.blank? }
+        info_arr = c.content.strip.split("\n").reject(&:blank?)
         info = {
           member: info_arr[0],
           title: info_arr[1].lstrip,

--- a/lib/sakamichi_scraper/sakurazaka.rb
+++ b/lib/sakamichi_scraper/sakurazaka.rb
@@ -35,6 +35,18 @@ module SakamichiScraper
       download_images_from_url_list(image_urls)
     end
 
+    def members_name_kanji
+      extract_member_list(target: "name_ja")
+    end
+
+    def members_name_hiragana
+      extract_member_list(target: "name_ja_hiragana")
+    end
+
+    def members_name_en
+      extract_member_list(target: "name_en")
+    end
+
     private
 
     def article_urls_from_list_page(html)

--- a/lib/sakamichi_scraper/sakurazaka.rb
+++ b/lib/sakamichi_scraper/sakurazaka.rb
@@ -19,7 +19,7 @@ module SakamichiScraper
       Nokogiri.parse(blog_list_page, nil, nil).css(".com-blog-part.box4.fxpc > li").each do |c|
         info = {
           member: c.css(".prof-in.fx > .name").children.to_s,
-          title:  c.css(".date-title > .title").children.to_s,
+          title: c.css(".date-title > .title").children.to_s,
           timestamp: c.css(".date.wf-a").children.to_s
         }
         res << info

--- a/lib/sakamichi_scraper/version.rb
+++ b/lib/sakamichi_scraper/version.rb
@@ -1,3 +1,3 @@
 module SakamichiScraper
-  VERSION = "0.2.1"
+  VERSION = "0.2.1".freeze
 end

--- a/spec/sakurazaka_spec.rb
+++ b/spec/sakurazaka_spec.rb
@@ -38,4 +38,28 @@ RSpec.describe(SakamichiScraper::Sakurazaka) do
       expect(Dir.glob("#{image_path}/*.jpg").count).to be >= 1
     end
   end
+
+  context "members_name_kanji" do
+    it "櫻坂46の漢字のメンバー名一覧が返却されること" do
+      expect_res = %w(上村莉菜 小池美波 小林由依 齋藤冬優花 土生瑞穂 井上梨名 遠藤光莉 大園玲 大沼晶保 幸坂茉里乃 武元唯衣 田村保乃
+                      藤吉夏鈴 増本綺良 松田里奈 森田ひかる 守屋麗奈 山﨑天 石森璃花 遠藤理子 小田倉麗奈 小島凪紗 谷口愛梨 中島優月 的野美青 向井純葉 村井優 村山美羽 山下瞳月)
+      expect(@sakurazaka.members_name_kanji).to eq expect_res
+    end
+  end
+
+  context "members_name_hiragana" do
+    it "櫻坂46のひらがなのメンバー名一覧が返却されること" do
+      expect_res = %w(うえむらりな こいけみなみ こばやしゆい さいとうふゆか はぶみづほ いのうえりな えんどうひかり おおぞのれい おおぬまおきほ
+                      こうさかまりの たけもとゆい たむらほの ふじよしかりん ますもときら まつだりな もりたひかる もりやれな やまさきてん いしもりりか えんどうりこ おだくられいな こじまなぎさ たにぐちあいり なかしまゆづき まとのみお むかいいとは むらいゆう むらやまみう やましたしづき)
+      expect(@sakurazaka.members_name_hiragana).to eq expect_res
+    end
+  end
+
+  context "members_name_en" do
+    it "櫻坂46のアルファベットのメンバー名一覧が返却されること" do
+      expect_res = ["Rina Uemura", "Minami Koike", "Yui Kobayashi", "Fuyuka Saito", "Mizuho Habu", "Rina Inoue",
+                    "Hikari Endo", "Rei Ozono", "Akiho Onuma", "Marino Kosaka", "Yui Takemoto", "Hono Tamura", "Karin Fujiyoshi", "Kira Masumoto", "Rina Matsuda", "Hikaru Morita", "Rena Moriya", "Ten Yamasaki", "Rika Ishimori", "Riko Endo", "Reina Odakura", "Nagisa Kojima", "Airi Taniguchi", "Yuzuki Nakashima", "Mio Matono", "Itoha Mukai", "Yu Murai", "Miu Murayama", "Shizuki Yamashita"]
+      expect(@sakurazaka.members_name_en).to eq expect_res
+    end
+  end
 end


### PR DESCRIPTION
# What
- 櫻坂のメンバー名を返す関数を追加した（いずれもArray）
  - `members_name_kanji`: 漢字
  - `members_name_hiragana` : 平仮名
  - `members_name_en`: 英語
- ↑の関数の土台になるymlの追加
- (ようやく)Rubocopを動かしたのでその修正